### PR TITLE
Fix spelling in himData.json

### DIFF
--- a/Visual/himData.json
+++ b/Visual/himData.json
@@ -10,7 +10,7 @@
  "Surgery" : "_6.gW.o.oKC9E.eS.h.g4.t.qTN.s.dBQ-content.html",
  "Womens Health" : "_5.tF9.sJZ.dE.eKF.i.rS.q.o8ABDA-content.html",
  "Vitals" : "_.xD.p.z.sLH.dE.eKHA.pZW0Z.g.i3Q-content.html",
- "VistaLink" : "_.oS.a.dUI.nCE.eOA9.p.o.uB.wB4_A-content.html",
+ "VistALink" : "_.oS.a.dUI.nCE.eOA9.p.o.uB.wB4_A-content.html",
  "Toolkit" : "_E.k.dUQD.i.lE.eKJ.b5I84DDP9.g-content.html",
  "Text Integration Utility" : "_RB.dQ4B.o.vE.eK4.hKFZTL.eB.vA-content.html",
  "Scheduling" : "_O.hEW4F.y1E.eGK.k79K-A.nV2A-content.html",


### PR DESCRIPTION
Fix the spelling of the VistALink package, from VistaLink, so that the
HIM link for that package is displayed when the modal window is shown.