### PR TITLE
Remove Extra numbers from GenerateData.rst

### DIFF
--- a/Visual/Documentation/GenerateData.rst
+++ b/Visual/Documentation/GenerateData.rst
@@ -69,7 +69,7 @@ numbers:
           8994              Remote Procedure
            19                    Option
           779.2              HLO Application
-          9.779                  Install
+          9.7                  Install
  ======================= =======================
 
 An example command to be run would look like this:


### PR DESCRIPTION
The "Install" file information is contained in the 9.7 file, not 9.779.  Eliminate the extra numbers