### PR TITLE
Remove position arguments from modal window

### DIFF
--- a/Visual/bff_demo.php
+++ b/Visual/bff_demo.php
@@ -115,7 +115,7 @@ function text_onMouseClick(d) {
       height: 'auto',
       width: 700,
       modal: true,
-      position: ["center","center-50"],
+      position: {my: "center center-50", of: window},
       title: "" + d.number + ": " + d.name,
       open: function(){
           $('#description').html(d.description);

--- a/Visual/index.php
+++ b/Visual/index.php
@@ -163,7 +163,7 @@ function pkgLinkClicked(d) {
       height: 'auto',
       width: 700,
       modal: true,
-      position: ["center","center"],
+      position: {my: "center center", of: window},
       title: "Package: " + d.name,
       open: function(){
           htmlLnk = getInterfaceHtml(d);

--- a/Visual/vivian_osehra_image.php
+++ b/Visual/vivian_osehra_image.php
@@ -56,7 +56,7 @@
       height: 'auto',
       width: 500,
       modal: true,
-      position: ["center",150],
+      position: {my: "center 150", of: window},
       title: "About ViViaN(TM)"
     };
     $('#dialog-modal-about').dialog(overlayDialogObj).show();


### PR DESCRIPTION
Due to the update from JQuery 1.10.4 to 1.11.0, the array argument
for modal window positioning, ie "['center','center']" is no longer placing
the window correctly.  Remove the values and accept the default which
will put the window in the center of the screen for all instances.

OSEHRA-Id: http://issues.osehra.org/browse/VIVIAN-160