### PR TITLE
Split the circle and chart package dependency visualizations

### DIFF
--- a/Visual/test/test_index.py
+++ b/Visual/test/test_index.py
@@ -82,13 +82,19 @@ class test_index(unittest.TestCase):
       node_path = node.find_element_by_tag_name('path')
       if node_path.get_attribute('name') == 'circle':
         node_text = node.find_element_by_tag_name('text')
-        break;
+        # TODO: For some reason this fails for 'CPRS Plugins' and 'Kernel'?
+        if node_text.text == 'Automated Lab Instruments':
+          break;
+    else:
+      self.fail("Failed to find leaf node")
+
     # open dialog
     node_text.click()
+
     modal_title = driver.find_element_by_class_name('ui-dialog-title')
     self.assertTrue(re.search(node_text.text, modal_title.text))
 
-  def _test_06_modal_accordion(self):
+  def test_06_modal_accordion(self):
     global driver
 
     self.addCleanup(self.close_modal_dialog)
@@ -99,6 +105,8 @@ class test_index(unittest.TestCase):
       node_text = node.find_element_by_tag_name('text')
       if node_text.text == 'Barcode Medication Administration':
         break;
+    else:
+      self.fail("Failed to find leaf node")
 
     # Open modal dialog
     node_text.click()
@@ -119,8 +127,11 @@ class test_index(unittest.TestCase):
 
   def close_modal_dialog(self):
     global driver
-    modal_title = driver.find_element_by_class_name('ui-dialog-titlebar')
-    modal_title.find_element_by_tag_name("button").click()
+    try:
+      modal_title = driver.find_element_by_class_name('ui-dialog-titlebar')
+      modal_title.find_element_by_tag_name("button").click()
+    except:
+      pass
 
 
   def test_07_expand_collapse_nodes(self):

--- a/Visual/test/test_pkg_dependency.py
+++ b/Visual/test/test_pkg_dependency.py
@@ -48,7 +48,7 @@ class test_pkgdep(unittest.TestCase):
     global driver
 
     # Values taken from local instance, not the most sustainable but works for now
-    PCE_values = [39,23]
+    PCE_values = [40,23]
     ETiR_values = [0,6]
     CS_values = [3,0]
 
@@ -74,26 +74,16 @@ class test_pkgdep(unittest.TestCase):
     self.assertEqual(source_size, CS_values[0])
     self.assertEqual(target_size, CS_values[1])
 
-  def test_03_chart_switch(self):
-    global driver
-    btn_group = driver.find_element_by_class_name("btn-group")
-    for btn in btn_group.find_elements_by_tag_name("label"):
-      type = btn.text.split(' ')[0]
-      btn.click()
-      self.assertTrue("active" in btn.get_attribute("class"))
-      time.sleep(2)
-      if type == "Circular":
-        non_active_chart_id = "bar-chart"
-      else:
-        non_active_chart_id = "circular-chart"
-      chart = driver.find_element_by_id(non_active_chart_id)
-      self.assertTrue(re.search("display: none", chart.get_attribute("style")))
-
   def test_04_dep_bar_content(self):
+    global driver
+
+    driver.find_element_by_id('package-dependency').click()
+    driver.find_element_by_id('bar-chart').click()
+    time.sleep(1)
+
     chart_titles = ['VistA Packages Dependencies Chart','VistAPackageStatistics']
     dep_chart_legend = ['depends','dependents']
     dep_chart_top_entries = ['Kernel','Order Entry Results Reporting','Accounts Receivable']
-    global driver
 
     # Ensure that the data and labels of chart are not empty
     chart_container = driver.find_elements_by_class_name("highcharts-series")
@@ -106,19 +96,17 @@ class test_pkgdep(unittest.TestCase):
       bar_array = type.find_elements_by_tag_name("text")
       self.assertTrue(len(bar_array) > 0)
 
-
     # Read title of graph
-    bar_chart = driver.find_element_by_id("bar-chart")
-    title_element = bar_chart.find_element_by_class_name("highcharts-title")
+    title_element = driver.find_element_by_class_name("highcharts-title")
     self.assertTrue(title_element.text in chart_titles)
     # Ensure that legends have proper information
-    chart_legend = bar_chart.find_element_by_class_name("highcharts-legend")
+    chart_legend = driver.find_element_by_class_name("highcharts-legend")
     legend_array = chart_legend.find_elements_by_tag_name("text")
     for item in legend_array:
        self.assertTrue(item.get_attribute("innerHTML") in dep_chart_legend)
 
     # Check each of the "Sort By" selections to ensure that the first element is found in top_entries array
-    dep_pulldown = bar_chart.find_element_by_id("list-dep")
+    dep_pulldown = driver.find_element_by_id("list-dep")
     pulldown_options = Select(dep_pulldown)
     for option in pulldown_options.options:
       pulldown_options.select_by_visible_text(option.text)
@@ -127,8 +115,7 @@ class test_pkgdep(unittest.TestCase):
 
   def test_05_bar_switch(self):
     global driver
-    bar_chart = driver.find_element_by_id("bar-chart")
-    btn_group = bar_chart.find_element_by_class_name("btn-group")
+    btn_group = driver.find_element_by_class_name("btn-group")
     for btn in btn_group.find_elements_by_tag_name("label"):
       type = btn.text.split(' ')[0]
       btn.click()
@@ -153,18 +140,17 @@ class test_pkgdep(unittest.TestCase):
       self.assertTrue(len(bar_array) > 0)
 
     # Read title of graph
-    bar_chart = driver.find_element_by_id("bar-chart")
-    title_element = bar_chart.find_element_by_class_name("highcharts-title")
+    title_element = driver.find_element_by_class_name("highcharts-title")
     self.assertTrue(title_element.text in chart_titles)
 
     # Ensure that legends have proper information
-    chart_legend = bar_chart.find_element_by_class_name("highcharts-legend")
+    chart_legend = driver.find_element_by_class_name("highcharts-legend")
     legend_array = chart_legend.find_elements_by_tag_name("text")
     for item in legend_array:
        self.assertTrue(item.get_attribute("innerHTML") in stat_chart_legend)
 
     # Check each of the "Sort By" selections to ensure that the first element is found in top_entries array
-    dep_pulldown = bar_chart.find_element_by_id("list-stats")
+    dep_pulldown = driver.find_element_by_id("list-stats")
     pulldown_options = Select(dep_pulldown)
     for option in pulldown_options.options:
       pulldown_options.select_by_visible_text(option.text)

--- a/Visual/vista_menus.php
+++ b/Visual/vista_menus.php
@@ -64,7 +64,7 @@
 
   <div class='hint' style="position:relative; left:20px; top:50px">
     <p>
-    This tree visualization represents the menu hierarchy of VistA. Mouse over
+    This tree visualization represents the menu hierarchy of VistA. Hover over
     any of the entries in the tree to see the menu option name and the security
     key (if any). Click on an item to see the menu option details.
     </p>

--- a/Visual/vista_pkg_dep.php
+++ b/Visual/vista_pkg_dep.php
@@ -9,79 +9,38 @@
     ?>
     <?php include_once "vivian_google_analytics.php" ?>
     <script>
-    $(function() {
-      $('#navigation_buttons li').each(function (i) {
-        if (i === 3) {
-          $(this).removeClass().addClass("active");
-        }
-        else {
-          $(this).removeClass();
-        }
+      $(function() {
+        $('#navigation_buttons li').each(function (i) {
+          if (i === 3) {
+            $(this).removeClass().addClass("active");
+          }
+          else {
+            $(this).removeClass();
+          }
+        });
       });
-    });
     </script>
   </head>
 
 <body>
   <?php include_once "vivian_osehra_image.php" ?>
-  <div style="position:relative; left 20px; top:30px;">
-    <div class="btn-group" data-toggle="buttons" style="font-size:.8em; position:relative; left:20px; top:10px">
-      <label class="btn btn-primary btn-sm active">
-        <input type="radio" name="options" id="option1" value="0" checked> Circular Layout
-      </label>
-      <label class="btn btn-primary btn-sm">
-        <input type="radio" name="options" value="1" id="option2"> Bar Chart
-      </label>
-    </div>
 
-  <div id="bar-chart" style="display:none; font-size:0.8em">
-    <div class="btn-group" data-toggle="buttons" style="position:relative; left:20px; top:40px">
-      <label class="btn btn-primary btn-xs active">
-        <input type="radio" name="chart-option" id="option3" value="0" checked>Dependency Chart
-      </label>
-      <label class="btn btn-primary btn-xs">
-        <input type="radio" name="chart-option" value="1" id="option4">Stats Chart
-      </label>
-    </div>
-    <div style="position:relative; left:20px; top:50px">
-      <form id="frm-dep">
-        <label for="list-dep">Sorted By:</label>
-        <SELECT id="list-dep">
-            <OPTION VALUE="0">Name</OPTION>
-            <OPTION VALUE="1" selected="selected">Dependencies</OPTION>
-            <OPTION VALUE="2">Dependents</OPTION>
-        </SELECT>
-      </form>
-      <form id="frm-stats" style="display:none">
-        <label for="list-stats">Sorted By:</label>
-        <SELECT id="list-stats">
-            <OPTION VALUE="3">Name</OPTION>
-            <OPTION VALUE="4"  selected="selected">Routines</OPTION>
-            <OPTION VALUE="5">Files</OPTION>
-            <OPTION VALUE="6">File Fields</OPTION>
-        </SELECT>
-      </form>
-    </div>
-    <div id="container" style="position:relative; top:55px; width: 90%; height: 4200px; margin: 0 auto"></div>
+  <div class="hint" style="position:relative; left:20px; top:50px">
+    <p>This circle plot captures the interrelationships among VistA packages.</p>
+    <p>Hover over any of the packages in this graph to see incoming links (dependents)
+    in one color and the outgoing links (dependencies) in a second.
+    Click on any of the packages to view package dependency details.</p>
   </div>
-  <div id="circular-chart">
-    <div class='hint' style="position:relative; width:800px; top:50px; left:20px">
-      <p>
-  <div style="position:relative; top:50px; left:20px">
+
+  <div style="position:relative; top:75px; left:20px">
     <div id="legend_placeholder" style="float: left;"></div>
     <div style="float: left; margin-left:15px; margin-right:35px;">
       <label class="btn-primary btn-sm">
         <input type="checkbox" id="colorMode" onclick="javascript:swapColorScheme()"> Colorblind Mode </input>
       </label>
     </div>
-    <div class="hint" style="float: left; margin-left:15px; width:500px;">
-      This circle plot captures the interrelationships among VistA packages.
-      Mouse over any of the packages in this graph to see incoming links (dependents)
-      in one color and the outgoing links (dependencies) in a second. Click on
-      any of the packages to view package dependency.
-      details.
-    </div>
   </div>
+
   <div id="chart_placeholder"></div>
 
   <div id="toolTip" class="tooltip" style="opacity:0;">
@@ -96,10 +55,7 @@
   ${demo.css}
 </style>
 
-<script src="highcharts/highcharts.js"></script>
-
 <script type="text/javascript">
-
   var jsonData = [];
   var palette = "rg";
   var colorLegend = [{name: "Depends", colorClass: palette + "-link--source"},
@@ -107,10 +63,11 @@
   {name: "Both", colorClass: "link--target link--source"}];
 
   var legendColorChart = d3.chart.treeview()
-              .height(50)
-              .width(300)
-              .margins({top:42, left:10, right:0, bottom:0})
-              .textwidth(110);
+                          .height(50)
+                          .width(300)
+                          .margins({top:42, left:10, right:0, bottom:0})
+                          .textwidth(110);
+
   function swapColorScheme() {
     var shapeLegendText = legendColorChart.svg().selectAll("text")
     $("#colorMode").toggleClass("active");
@@ -121,13 +78,14 @@
       palette = "rg";
     }
     shapeLegendText
-      .filter( function(l) { console.log(l); if(l) return l.name === "Dependents"})
+      .filter( function(l) { if(l) return l.name === "Dependents"})
       .attr("class", function(d) {return palette + "-link--target";});
     shapeLegendText
-      .filter( function(l) { console.log(l); if(l) return l.name === "Depends"})
+      .filter( function(l) { if(l) return l.name === "Depends"})
       .attr("class", function(d) {return palette + "-link--source";});
     shapeLegendText.transition();
   }
+
   d3.json("PackageCategories.json", function(error, data) {
     var categories = data;
     function getPackageDoxLink(node) {
@@ -172,7 +130,7 @@
           }
         }
         return node;
-      }
+      } // end setCategory()
 
       setCategory(categories);
       for (var node_name in map) {
@@ -182,7 +140,7 @@
         }
       }
       return map[categories.name];
-    }
+    } // end packageHierarchyByGroups
 
     function mouseOvered(d) {
       var header1Text = "Name: " + d.name + "</br> Group: " + d.parent.name + "</br>";
@@ -219,12 +177,13 @@
     }
 
     var chart = d3.chart.dependencyedgebundling()
-             .packageHierarchy(packageHierarchyByGroups)
-             .mouseOvered(mouseOvered)
-             .mouseOuted(mouseOuted)
-             .nodeTextHyperLink(getPackageDoxLink);
+                .packageHierarchy(packageHierarchyByGroups)
+                .mouseOvered(mouseOvered)
+                .mouseOuted(mouseOuted)
+                .nodeTextHyperLink(getPackageDoxLink);
     var localpath = "pkgdep.json";
     d3.select("#legend_placeholder").datum(null).call(legendColorChart);
+
     d3.json(localpath, function(error, classes) {
       jsonData = classes;
       if (error){
@@ -236,286 +195,38 @@
       d3.select('#chart_placeholder')
         .datum(classes)
         .call(chart);
-      setupBarChart();
       createColorLegend(legendColorChart);
     });
   });
 
-    var options = {
-        chart: {
-            type: 'bar'
-        },
-        title: {
-            text: 'VistA Packages Dependencies Chart'
-        },
-        xAxis: {
-          categories: [],
-          labels: {
-            formatter: function (){
-              var package_link_url = "http://code.osehra.org/dox/";
-              var doxLinkName = this.value.replace(/ /g, '_').replace(/-/g, '_')
-              var lnkUrl = package_link_url + "Package_" + doxLinkName + ".html";
-              return "<a href=\"" + lnkUrl + "\"" + " target=\"_blank\"" + ">" + this.value + "</a>";
-            },
-            useHTML: true,
-            enabled: true
-          },
-        },
-        yAxis: {
-            min: 0,
-            title: {
-                //text: 'Total Number Of Dependencies'
-                text: null
-            },
-        },
-        legend: {
-            align: 'right',
-            x: -70,
-            verticalAlign: 'top',
-            y: 20,
-            floating: true,
-            backgroundColor: (Highcharts.theme && Highcharts.theme.background2) || 'white',
-            borderColor: '#CCC',
-            borderWidth: 1,
-            shadow: false
-        },
-        tooltip: {
-            formatter: function () {
-                var ttp = '<b>' + this.x + '</b><br/>';
-                $.each(this.points, function(){
-                  ttp += this.series.name + ': ' + this.y + '<br/>' + '';
-                });
-                return ttp;
-            },
-            shared: true
-        },
-        plotOptions: {
-            bar: {
-                //stacking: 'normal',
-                dataLabels: {
-                    enabled: true
-                }
-            }
-        },
-        credits: {
-          enabled: false
-        },
-        series: []
-    };
+  function createColorLegend(legendColorChart) {
+    var colorLegendDisplay = legendColorChart.svg().selectAll("g.shapeLegend")
+        .data(colorLegend)
+        .enter().append("svg:g")
+        .attr("class", "shapeLegend")
+        .attr("transform", function(d, i) { return "translate("+(i * 115) +", -10)"; });
 
-    function sortByNoRoutines(one, two) {
-      return sortByProp(one, two, "routines");
-    }
+    colorLegendDisplay.append("path")
+        .attr("class", function(d) {return d.colorClass;})
+        .attr("r", 3);
 
-    function sortByNoFiles(one, two) {
-      return sortByProp(one, two, "files");
-    }
-
-    function sortByNoFileFields(one, two) {
-      return sortByProp(one, two, "fields");
-    }
-
-    function sortByNoDepends(one, two) {
-      return sortByProp(one, two, "depends");
-    }
-
-    function sortByNoDependents(one, two) {
-      return sortByProp(one, two, "dependents");
-    }
-
-    function sortByName(one, two) {
-      if (one.name > two.name) {
-        return 1;
-      }
-      if (one.name < two.name) {
-        return -1;
-      }
-      return 0;
-    }
-
-    function sortByProp(one, two, property) {
-      if (property in one && property in two) {
-        if (two[property] instanceof Array) {
-          return two[property].length - one[property].length;
-        }
-        else {
-          return two[property] - one[property];
-        }
-      }
-      if (property in one) {
-        return -1;
-      }
-      return 1;
-    }
-
-    function getSeriesByJson(data, property) {
-      var totLen = data.length;
-      var outSeries = {"data":[], "name": property};
-      for (var idx = 0; idx < totLen; idx++) {
-        if (property in data[idx]) {
-          if (data[idx][property] instanceof Array) {
-            outSeries.data.push(data[idx][property].length);
-          }
-          else {
-            outSeries.data.push(data[idx][property]);
-          }
-        }
-        else {
-          outSeries.data.push(0);
-        }
-      }
-      return outSeries;
-    }
-
-    function getJsonCategoriesArray(data) {
-      var totLen = data.length;
-      var categories = [];
-      for (var idx = 0; idx < totLen; idx++) {
-        if (data[idx].name && data[idx].name !== undefined) {
-          categories.push(data[idx].name);
-        }
-      }
-      return categories;
-    }
-
-    function setCategoriesByJson(data) {
-      options.xAxis.categories = getJsonCategoriesArray(data);
-    }
-
-    function setupBarChart() {
-    // read the chart data from json file
-      jsonData.sort(sortByNoDepends);
-      setCategoriesByJson(jsonData);
-      //setSeriesByJson(jsonData, "routines");
-      //setSeriesByJson(jsonData, "files");
-      var depData = getSeriesByJson(jsonData,"depends");
-      depData.color = "#d62728";
-      options.series.push(depData);
-      depData = getSeriesByJson(jsonData,"dependents");
-      depData.color = "#2ca02c";
-      options.series.push(depData);
-      $('#container').highcharts(options);
-    }
-
-    // utility function for resetting chart data
-    function resetChartData(val) {
-      var chart = $("#container").highcharts();
-      while( chart.series.length > 0 ) {
-       chart.series[0].remove( false );
-      }
-      if (val == 0 || val == 3) {
-        jsonData.sort(sortByName);
-      }
-      else if (val == 1) {
-        jsonData.sort(sortByNoDepends);
-      }
-      else if (val == 2){
-        jsonData.sort(sortByNoDependents);
-      }
-      else if (val == 4){
-        jsonData.sort(sortByNoRoutines);
-      }
-      else if (val == 5){
-        jsonData.sort(sortByNoFiles);
-      }
-      else if (val == 6){
-        jsonData.sort(sortByNoFileFields);
-      }
-      chart.xAxis[0].setCategories(getJsonCategoriesArray(jsonData), false);
-      var depData;
-      if (val < 3) {
-        depData = getSeriesByJson(jsonData,"depends");
-        depData.color = "#d62728";
-        chart.addSeries(depData);
-        depData = getSeriesByJson(jsonData,"dependents");
-        depData.color = "#2ca02c";
-        chart.addSeries(depData);
-      }
-      else {
-        depData = getSeriesByJson(jsonData,"routines");
-        depData.color = "#d62728";
-        chart.addSeries(depData);
-        depData = getSeriesByJson(jsonData,"files");
-        depData.color = "#2ca02c";
-        chart.addSeries(depData);
-        depData = getSeriesByJson(jsonData,"fields");
-        depData.color = "#3399FF";
-        chart.addSeries(depData);
-      }
-      chart.redraw();
-    }
-$(function () {
-
-    $(' #list-dep').change(function(e) {
-      resetChartData($(this).val());
-    });
-    $(' #list-stats').change(function(e) {
-      resetChartData($(this).val());
-    });
-
-    $("input:radio[name='chart-option']").change(function() {
-        var chart = $("#container").highcharts();
-        var value = $(this).val();
-        console.log(value);
-        if (value == 1) {
-          $('#frm-dep').hide();
-          $('#frm-stats').show();
-          chart.setTitle({text: "VistA Package Statistics"});
-          resetChartData($("#list-stats").val());
-        }
-        else {
-          chart.setTitle({text: "VistA Package Dependencies"});
-          $('#frm-stats').hide();
-          $('#frm-dep').show();
-          resetChartData($("#list-dep").val());
-        }
-    });
-
-    $("input:radio[name='options']").change(function() {
-        var value = $(this).val();
-        console.log(value);
-        if (value == 1) {
-          $('#circular-chart').hide();
-          $('#bar-chart').show();
-        }
-        else if (value == 0) {
-          $('#bar-chart').hide();
-          $('#circular-chart').show();
-        }
-    });
-
-});
-
-
-function createColorLegend(legendColorChart) {
-  var colorLegendDisplay = legendColorChart.svg().selectAll("g.shapeLegend")
-      .data(colorLegend)
-      .enter().append("svg:g")
-      .attr("class", "shapeLegend")
-      .attr("transform", function(d, i) { return "translate("+(i * 115) +", -10)"; });
-
-  colorLegendDisplay.append("path")
-      .attr("class", function(d) {return d.colorClass;})
-      .attr("r", 3);
-
-  colorLegendDisplay.append("svg:text")
-      .attr("class", function(d) {return d.colorClass;})
-      .attr("id", function(d) {return d.name;})
-      .attr("x", 13)
-      .attr("dy", ".31em")
-      .text(function(d) {
-        return  d.name;
-      });
-  var colorLegendDisplay = legendColorChart.svg();
-  colorLegendDisplay.append("text")
-          .attr("x", 0)
-          .attr("y", -28 )
-          .attr("text-anchor", "left")
-          .style("font-size", "16px")
-          .text("Color Legend");
-}
-  </script>
-
-  </body>
+    colorLegendDisplay.append("svg:text")
+        .attr("class", function(d) {return d.colorClass;})
+        .attr("id", function(d) {return d.name;})
+        .attr("x", 13)
+        .attr("dy", ".31em")
+        .text(function(d) {
+          return  d.name;
+        });
+    var colorLegendDisplay = legendColorChart.svg();
+    colorLegendDisplay.append("text")
+            .attr("x", 0)
+            .attr("y", -28 )
+            .attr("text-anchor", "left")
+            .style("font-size", "16px")
+            .text("Color Legend");
+  }
+</script>
+</body>
 </html>
 

--- a/Visual/vista_pkg_dep_chart.php
+++ b/Visual/vista_pkg_dep_chart.php
@@ -1,0 +1,333 @@
+<!DOCTYPE html>
+<html>
+  <title>VistA Package Dependency</title>
+  <head>
+    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700|Roboto:400,700' rel='stylesheet' type='text/css'>
+    <?php
+      include_once "vivian_common_header.php";
+      include_once "d3.dependencyedgebundling.css";
+    ?>
+    <?php include_once "vivian_google_analytics.php" ?>
+    <script>
+      $(function() {
+        $('#navigation_buttons li').each(function (i) {
+          if (i === 3) {
+            $(this).removeClass().addClass("active");
+          }
+          else {
+            $(this).removeClass();
+          }
+        });
+      });
+    </script>
+  </head>
+
+<body>
+  <?php include_once "vivian_osehra_image.php" ?>
+
+  <div style="position:relative; left:20px; top:50px">
+    <div class="btn-group" data-toggle="buttons">
+      <label class="btn btn-primary btn-xs active">
+        <input type="radio" name="chart-option" id="option3" value="0" checked>Dependency Chart
+      </label>
+      <label class="btn btn-primary btn-xs">
+        <input type="radio" name="chart-option" value="1" id="option4">Stats Chart
+      </label>
+    </div>
+    </br>
+    </br>
+    <div style="font-size:0.8em">
+      <form id="frm-dep">
+        <label for="list-dep">Sorted By:</label>
+        <SELECT id="list-dep">
+            <OPTION VALUE="0">Name</OPTION>
+            <OPTION VALUE="1" selected="selected">Dependencies</OPTION>
+            <OPTION VALUE="2">Dependents</OPTION>
+        </SELECT>
+      </form>
+      <form id="frm-stats" style="display:none">
+        <label for="list-stats">Sorted By:</label>
+        <SELECT id="list-stats">
+            <OPTION VALUE="3">Name</OPTION>
+            <OPTION VALUE="4"  selected="selected">Routines</OPTION>
+            <OPTION VALUE="5">Files</OPTION>
+            <OPTION VALUE="6">File Fields</OPTION>
+        </SELECT>
+      </form>
+    </div>
+  </div>
+
+  <div id="container" style="position:relative; top:55px; width: 90%; height: 4200px; margin: 0 auto"></div>
+
+ <style type="text/css">
+  ${demo.css}
+</style>
+
+<script src="highcharts/highcharts.js"></script>
+
+<script type="text/javascript">
+  var jsonData = [];
+
+  d3.json("PackageCategories.json", function(error, data) {
+    var localpath = "pkgdep.json";
+    d3.json(localpath, function(error, classes) {
+      jsonData = classes;
+      if (error){
+        errormsg = "json error " + error + " data: " + classes;
+        document.write(errormsg);
+        return;
+      }
+      classes.sort();
+      setupBarChart();
+    });
+  });
+
+  var options = {
+    chart: {
+        type: 'bar'
+    },
+    title: {
+        text: 'VistA Packages Dependencies Chart'
+    },
+    xAxis: {
+      categories: [],
+      labels: {
+        formatter: function (){
+          var package_link_url = "http://code.osehra.org/dox/";
+          var doxLinkName = this.value.replace(/ /g, '_').replace(/-/g, '_')
+          var lnkUrl = package_link_url + "Package_" + doxLinkName + ".html";
+          return "<a href=\"" + lnkUrl + "\"" + " target=\"_blank\"" + ">" + this.value + "</a>";
+        },
+        useHTML: true,
+        enabled: true
+      },
+    },
+    yAxis: {
+        min: 0,
+        title: {
+            //text: 'Total Number Of Dependencies'
+            text: null
+        },
+    },
+    legend: {
+        align: 'right',
+        x: -70,
+        verticalAlign: 'top',
+        y: 20,
+        floating: true,
+        backgroundColor: (Highcharts.theme && Highcharts.theme.background2) || 'white',
+        borderColor: '#CCC',
+        borderWidth: 1,
+        shadow: false
+    },
+    tooltip: {
+        formatter: function () {
+            var ttp = '<b>' + this.x + '</b><br/>';
+            $.each(this.points, function(){
+              ttp += this.series.name + ': ' + this.y + '<br/>' + '';
+            });
+            return ttp;
+        },
+        shared: true
+    },
+    plotOptions: {
+        bar: {
+            //stacking: 'normal',
+            dataLabels: {
+                enabled: true
+            }
+        }
+    },
+    credits: {
+      enabled: false
+    },
+    series: []
+  };
+
+  function sortByNoRoutines(one, two) {
+    return sortByProp(one, two, "routines");
+  }
+
+  function sortByNoFiles(one, two) {
+    return sortByProp(one, two, "files");
+  }
+
+  function sortByNoFileFields(one, two) {
+    return sortByProp(one, two, "fields");
+  }
+
+  function sortByNoDepends(one, two) {
+    return sortByProp(one, two, "depends");
+  }
+
+  function sortByNoDependents(one, two) {
+    return sortByProp(one, two, "dependents");
+  }
+
+  function sortByName(one, two) {
+    if (one.name > two.name) {
+      return 1;
+    }
+    if (one.name < two.name) {
+      return -1;
+    }
+    return 0;
+  }
+
+  function sortByProp(one, two, property) {
+    if (property in one && property in two) {
+      if (two[property] instanceof Array) {
+        return two[property].length - one[property].length;
+      }
+      else {
+        return two[property] - one[property];
+      }
+    }
+    if (property in one) {
+      return -1;
+    }
+    return 1;
+  }
+
+  function getSeriesByJson(data, property) {
+    var totLen = data.length;
+    var outSeries = {"data":[], "name": property};
+    for (var idx = 0; idx < totLen; idx++) {
+      if (property in data[idx]) {
+        if (data[idx][property] instanceof Array) {
+          outSeries.data.push(data[idx][property].length);
+        }
+        else {
+          outSeries.data.push(data[idx][property]);
+        }
+      }
+      else {
+        outSeries.data.push(0);
+      }
+    }
+    return outSeries;
+  }
+
+  function getJsonCategoriesArray(data) {
+    var totLen = data.length;
+    var categories = [];
+    for (var idx = 0; idx < totLen; idx++) {
+      if (data[idx].name && data[idx].name !== undefined) {
+        categories.push(data[idx].name);
+      }
+    }
+    return categories;
+  }
+
+  function setCategoriesByJson(data) {
+    options.xAxis.categories = getJsonCategoriesArray(data);
+  }
+
+  function setupBarChart() {
+  // read the chart data from json file
+    jsonData.sort(sortByNoDepends);
+    setCategoriesByJson(jsonData);
+    //setSeriesByJson(jsonData, "routines");
+    //setSeriesByJson(jsonData, "files");
+    var depData = getSeriesByJson(jsonData,"depends");
+    depData.color = "#d62728";
+    options.series.push(depData);
+    depData = getSeriesByJson(jsonData,"dependents");
+    depData.color = "#2ca02c";
+    options.series.push(depData);
+    $('#container').highcharts(options);
+  }
+
+  // utility function for resetting chart data
+  function resetChartData(val) {
+    var chart = $("#container").highcharts();
+    while( chart.series.length > 0 ) {
+      chart.series[0].remove( false );
+    }
+    if (val == 0 || val == 3) {
+      jsonData.sort(sortByName);
+    }
+    else if (val == 1) {
+      jsonData.sort(sortByNoDepends);
+    }
+    else if (val == 2){
+      jsonData.sort(sortByNoDependents);
+    }
+    else if (val == 4){
+      jsonData.sort(sortByNoRoutines);
+    }
+    else if (val == 5){
+      jsonData.sort(sortByNoFiles);
+    }
+    else if (val == 6){
+      jsonData.sort(sortByNoFileFields);
+    }
+    chart.xAxis[0].setCategories(getJsonCategoriesArray(jsonData), false);
+    var depData;
+    if (val < 3) {
+      depData = getSeriesByJson(jsonData,"depends");
+      depData.color = "#d62728";
+      chart.addSeries(depData);
+      depData = getSeriesByJson(jsonData,"dependents");
+      depData.color = "#2ca02c";
+      chart.addSeries(depData);
+    }
+    else {
+      depData = getSeriesByJson(jsonData,"routines");
+      depData.color = "#d62728";
+      chart.addSeries(depData);
+      depData = getSeriesByJson(jsonData,"files");
+      depData.color = "#2ca02c";
+      chart.addSeries(depData);
+      depData = getSeriesByJson(jsonData,"fields");
+      depData.color = "#3399FF";
+      chart.addSeries(depData);
+    }
+    chart.redraw();
+  }
+
+$(function() {
+    $(' #list-dep').change(function(e) {
+      resetChartData($(this).val());
+    });
+    $(' #list-stats').change(function(e) {
+      resetChartData($(this).val());
+    });
+
+    $("input:radio[name='chart-option']").change(function() {
+        var chart = $("#container").highcharts();
+        var value = $(this).val();
+        if (value == 1) {
+          $('#frm-dep').hide();
+          $('#frm-stats').show();
+          chart.setTitle({text: "VistA Package Statistics"});
+          resetChartData($("#list-stats").val());
+        }
+        else {
+          chart.setTitle({text: "VistA Package Dependencies"});
+          $('#frm-stats').hide();
+          $('#frm-dep').show();
+          resetChartData($("#list-dep").val());
+        }
+    });
+
+    $("input:radio[name='options']").change(function() {
+        var value = $(this).val();
+        console.log(value);
+        if (value == 1) {
+          $('#circular-chart').hide();
+          $('#bar-chart').show();
+        }
+        else if (value == 0) {
+          $('#bar-chart').hide();
+          $('#circular-chart').show();
+        }
+    });
+
+});
+
+</script>
+
+</body>
+</html>
+

--- a/Visual/vivian_osehra_image.php
+++ b/Visual/vivian_osehra_image.php
@@ -15,17 +15,23 @@
     <nav class="navbar navbar-default navbar-static-top">
       <div class="container-fluid">
         <ul class="nav navbar-nav">
-          <li>
-          <a class="brand" href="index.php"> <img width="137" height="50" src="http://osehra.org/sites/default/files/vivian.png"></img></a></li>
+          <li><a class="brand" href="index.php"><img width="137" height="50" src="http://osehra.org/sites/default/files/vivian.png"></img></a></li>
           <li><a href="vista_menus.php">VistA Menus</a></li>
           <li><a href="bff_demo.php">VHA BFF Demo</a></li>
-          <li><a href="vista_pkg_dep.php">VistA Package Dependency</a></li>
+          <li class="dropdown" id="package-dependency">
+            <a class="dropdown-toggle" data-toggle="dropdown" href="#">VistA Package Dependency<span class="caret"></span></a>
+            <ul class="dropdown-menu">
+              <li><a href="vista_pkg_dep.php" id="circle-layout">Circular Layout</a></li>
+              <li><a href="vista_pkg_dep_chart.php" id="bar-chart">Bar Chart</a></li>
+            </ul>
+          </li>
           <li class="dropdown">
             <a class="dropdown-toggle" data-toggle="dropdown" href="#">VistA Install<span class="caret"></span></a>
             <ul class="dropdown-menu">
               <li><a href="installScale.php">Install Timeline</a></li>
               <li><a href="patchDependency.php">Install Dependency Tree</a></li>
             </ul>
+          </li>
         </ul>
         <ul class="nav navbar-nav navbar-right">
           <li><a href="javascript:aboutClicked();">About</a></li>


### PR DESCRIPTION
Each visualization now has it's on script. Switch between the two using the drop-down on the navigation bar.

The tooltips are now aligned correctly on the circle graph.

Updated tests. 