### PR TITLE
Fix inital stop date to show Dec 31 of current year

### DIFF
--- a/Visual/installScale.php
+++ b/Visual/installScale.php
@@ -83,7 +83,7 @@ var index = 0
 colors = d3.scale.category20b()
 backgroundColors = d3.scale.category20()
 var currentDate = new Date();
-var endDate = currentDate.getFullYear()+"-12-31"
+var endDate = "12/31/"+ currentDate.getFullYear()
 $("#timeline_date_start").datepicker()
 $("#timeline_date_stop").datepicker()
 


### PR DESCRIPTION
Change the "stop" string from "year-mon-day" to "mon/day/year" to prevent
an inconsitency in how Javascript parses the date string.

The previous structure caused the new Date object to be 5 hours earlier to
account for GMT:

  2016-12-31
  Fri Dec 30 2016 19:00:00 GMT-0500 (Eastern Standard Time)

while the new format returns as expected:

  12/31/2016
  Sat Dec 31 2016 00:00:00 GMT-0500 (Eastern Standard Time)