### PR TITLE
Add text to the "About" dialog about back-end info

### DIFF
--- a/Visual/Documentation/GenerateData.rst
+++ b/Visual/Documentation/GenerateData.rst
@@ -39,7 +39,7 @@ The FileManGlobalDataParser.py file’s execution signature is as follows:
 .. parsed-literal::
 
   usage: FileManGlobalDataParser.py [-h] -mr MREPOSITDIR -pr PATCHREPOSITDIR
-                                    [-outdir OUTDIR] [-all]
+                                    [-outdir OUTDIR] -gp GITPATH [-all]
                                     fileNos [fileNos ...]
 
   FileMan Global Data Parser
@@ -50,6 +50,8 @@ The FileManGlobalDataParser.py file’s execution signature is as follows:
   optional arguments:
     -h, --help            show this help message and exit
     -outdir OUTDIR        top directory to generate output in html
+    -gp GITPATH, --gitPath GITPATH
+                          Path to the folder containing git excecutable
     -all                  generate all dependency files as well
 
   Initial CrossReference Generator Arguments:
@@ -78,7 +80,7 @@ An example command to be run would look like this:
 
 .. parsed-literal::
 
-  $ python FileManGlobalDataParser.py -mr ~/Work/OSEHRA/VistA-M -pr ~/work/osehra/VistA -outdir ~/Work/OSEHRA/vivian-out -all 101 8994 19 779.2 9.7
+  $ python FileManGlobalDataParser.py -mr ~/Work/OSEHRA/VistA-M -pr ~/work/osehra/VistA -gp /usr/local/bin -outdir ~/Work/OSEHRA/vivian-out -all 101 8994 19 779.2 9.7
 
 ICRParser
 ~~~~~~~~~

--- a/Visual/vivian_osehra_image.php
+++ b/Visual/vivian_osehra_image.php
@@ -57,15 +57,20 @@
 
 <script>
   function aboutClicked(){
-    var overlayDialogObj = {
-      autoOpen: true,
-      height: 'auto',
-      width: 500,
-      modal: true,
-      position: {my: "center 150", of: window},
-      title: "About ViViaN(TM)"
-    };
-    $('#dialog-modal-about').dialog(overlayDialogObj).show();
+    d3.json("files/filesInfo.json", function(json) {
+      console.log($('#dialog-modal-dataVersion'))
+      $('#dialog-modal-dataVersion').text("The information in this instance of ViViaN was generated on:  "+json["date"] +
+                                          " from the OSEHRA VistA-M repository with a Git hash of:  "+ json["sha1"]);
+    });
+      var overlayDialogObj = {
+        autoOpen: true,
+        height: 'auto',
+        width: 500,
+        modal: true,
+        position: {my: "center 150", of: window},
+        title: "About ViViaN(TM)"
+      };
+      $('#dialog-modal-about').dialog(overlayDialogObj).show();
   }
 </script>
 
@@ -81,5 +86,6 @@
     tree-based visualizations of VistA menus and the VHA Business Function Framework
     categorization; as well as circle plots of the interaction network among VistA packages.
     </p>
+    <p id="dialog-modal-dataVersion"></p>
   </div>
 </div>


### PR DESCRIPTION
Add text to the information in the "About" dialog which tells when the
information was generated last and with what Git hash of the VistA-M
repository was used.