### PR TITLE
Fix the link generation by the Dependency chord vis

### DIFF
--- a/Visual/d3.dependencyedgebundling.js
+++ b/Visual/d3.dependencyedgebundling.js
@@ -79,7 +79,8 @@ d3.chart.dependencyedgebundling = function(options) {
   // Return a list of depends for the given array of nodes.
   var packageDepends = function (nodes) {
     var map = {},
-        depends = [];
+        depends = [],
+        dependents =[];
 
     // Compute a map from name to node.
     nodes.forEach(function(d) {
@@ -91,9 +92,12 @@ d3.chart.dependencyedgebundling = function(options) {
       if (d.depends) d.depends.forEach(function(i) {
         depends.push({source: map[d.name], target: map[i]});
       });
+      if (d.dependents) d.dependents.forEach(function(i) {
+        dependents.push({source: map[i], target: map[d.name]});
+      });
     });
-
-    return depends;
+    var result = $.merge(depends,dependents)
+    return result;
   }
 
   function chart(selection) {


### PR DESCRIPTION
Fix the link generation to also use the dependents information when
generating the links for the chord diagram of the VistA Package Dependency
page.
