### PR TITLE
Remove "Core Applications" from menu test

### DIFF
--- a/Visual/test/test_menus.py
+++ b/Visual/test/test_menus.py
@@ -65,7 +65,7 @@ class test_menus(unittest.TestCase):
 
   def test_04_menu_autocomplete(self):
     global driver
-    target_menu_text = "Core Applications"
+    target_menu_text = "TimeKeeper Main Menu"
     ac_form = driver.find_element_by_id("autocomplete")
     ac_form.clear()
     ac_form.send_keys(target_menu_text)


### PR DESCRIPTION
Remove the usage of the "Core Applications" menu in the autocomplete test
as it is no longer considered a "top level" menu.