### PR TITLE
Remove ZZSERVERMENU links in Menu display

### DIFF
--- a/Visual/vista_menus.php
+++ b/Visual/vista_menus.php
@@ -120,7 +120,7 @@ var chart = d3.chart.treeview()
               .margins({top: 0, left: 200, bottom: 0, right: 0})
               .textwidth(300)
               .pannableTree(true)
-              .nodeTextHyperLink(getOptionDetailLink);
+              .nodeTextHyperLink(function(d) { if (d.hasLink) return getOptionDetailLink(d);});
 var legendShapeChart = d3.chart.treeview()
               .height(50)
               .width(250)


### PR DESCRIPTION
Only show links to the HTML entry for an install that has a "hasLink"
parameter of 'true'.  When used with
http://review.code.osehra.org/#/c/876/, will prevent links on the
ZZSERVERMENU display from pointing to non-existant files.

OSEHRA-Id: http://issues.osehra.org/browse/VIVIAN-211