### PR TITLE
Fix BFF Description setting

### DIFF
--- a/Visual/bff_demo.php
+++ b/Visual/bff_demo.php
@@ -46,7 +46,7 @@
     </div>
   </br>
   </br>
-  <div id='description' class='hint'  style="position:relative; top:10px; left:20px; margin-right:200px;">
+  <div id='pageDescription' class='hint'  style="position:relative; top:10px; left:20px; margin-right:200px;">
     <p>
     This tree graph represents the VHA Business Function Framework (BFF).
     The BFF is a hierarchical construct that describes VHA business functions


### PR DESCRIPTION
Change the ID for the page description to not be "description".  This was
being overwritten by the attempt to generate the modal window which put
the description in that location instead of correctly in the pop-up
window.