### PR TITLE
Change colors of Unfulfilled Requirement nodes

### DIFF
--- a/Visual/bff_demo.php
+++ b/Visual/bff_demo.php
@@ -349,15 +349,15 @@ function createShapeLegend() {
       .attr("class", function(d) {return d.name;})
       .attr("d", d3.svg.symbol().type(function(d) { return d.shape;}))
       .style("fill", function(d) {
-          var color = "lightsteelblue"
-          if (d.hasRequirements) { color = "MidnightBlue"}
-          return d._children ? color : "#FFF";
+        var color = "#1bb15c"
+        if (d.hasRequirements) { color = "#7C84DE"}
+        return d._children ? color : "#FFF";
       })
       .style("stroke", function(d) {
-        var color = "lightsteelblue"
-        if (d.hasRequirements || d.isRequirement) { color = "MidnightBlue"}
-        if (d.recentUpdate == "Update") {color = "darkorange"}
-        if (d.recentUpdate == "New Requirement") {color = "mediumorchid"}
+        var color = "#1bb15c"
+        if (d.hasRequirements || d.isRequirement) { color = "#7C84DE"}
+        if (d.recentUpdate == "Update") {color = "#DC7A20"}
+        if (d.recentUpdate == "New Requirement") {color = "#B03A57 "}
         return color
       })
       //      "stroke": function(d) {chart.findNodeStroke(d)},

--- a/Visual/d3.treeview.js
+++ b/Visual/d3.treeview.js
@@ -289,15 +289,15 @@ d3.chart.treeview = function(option) {
   }
 
   function fillNodeCircle(d) {
-    var color = "lightsteelblue"
-    if (d.hasRequirements) { color = "MidnightBlue"}
+    var color = "#1bb15c"
+    if (d.hasRequirements) { color = "#7C84DE"}
     return d._children ? color : "#FFF";
   }
   function findNodeStroke(d) {
-    var color = "lightsteelblue"
-    if (d.hasRequirements || d.isRequirement) { color = "MidnightBlue"}
-    if (d.recentUpdate == "Update") {color = "darkorange"}
-    if (d.recentUpdate == "New Requirement") {color = "mediumorchid"}
+    var color = "#1bb15c"
+    if (d.hasRequirements || d.isRequirement) { color = "#7C84DE"}
+    if (d.recentUpdate == "Update") {color = "#DC7A20"}
+    if (d.recentUpdate == "New Requirement") {color = "#B03A57 "}
     return color
   }
 


### PR DESCRIPTION
Switch the color scheme of the unfulfilled requirements page to eliminate
the potential confusion between the purple and dark blue shaded nodes.