### PR TITLE
Fix incorrect recursive trigger in Menu Setup

### DIFF
--- a/Visual/scripts/option_autocomplete_gen.py
+++ b/Visual/scripts/option_autocomplete_gen.py
@@ -16,8 +16,8 @@ def recurse_info(inJSON):
     menuItem['parent_name'] = parent_name
     if(not (menuItem in outjson)):
       outjson.append(menuItem)
-    if 'children' in inJSON:
-      for child in inJSON['children']:
+    if '_children' in inJSON:
+      for child in inJSON['_children']:
         recurse_info(child)
 
 def run():


### PR DESCRIPTION
Change the attribute that was used to look for a menu's children.  Due to
the change to the menu system, the files have their children nodes in
"_children" not "children"

This caused the option_autocomplete to duplicate the menu_autocomplete
values.