### PR TITLE
Rework menu highlighting to use filename

### DIFF
--- a/Visual/bff_demo.php
+++ b/Visual/bff_demo.php
@@ -12,13 +12,9 @@
         $( "button" ).button().click(function(event){
           event.preventDefault();
         });
-        $('#navigation_buttons li').each(function (i) {
-          if (i === 2) {
+        fileName = window.location.href.substring(window.location.href.lastIndexOf('/')+1)
+        $('a[href="'+fileName+'"]').parents("#navigation_buttons li").each(function (i) {
             $(this).removeClass().addClass("active");
-          }
-          else {
-            $(this).removeClass();
-          }
         });
       });
     </script>

--- a/Visual/index.php
+++ b/Visual/index.php
@@ -12,13 +12,9 @@
         $( "button" ).button().click(function(event){
           event.preventDefault();
         });
-        $('#navigation_buttons li').each(function (i) {
-          if (i === 0) {
-            $(this).removeClass("active").addClass("active");
-          }
-          else {
-            $(this).removeClass("active");
-          }
+        fileName = window.location.href.substring(window.location.href.lastIndexOf('/')+1)
+        $('a[href="'+fileName+'"]').parents("#navigation_buttons li").each(function (i) {
+            $(this).removeClass().addClass("active");
         });
 
         d3.json('files/packages_autocomplete.json', function(json) {

--- a/Visual/installScale.php
+++ b/Visual/installScale.php
@@ -12,13 +12,9 @@
         $( "button" ).button().click(function(event){
           event.preventDefault();
         });
-        $('#navigation_buttons li').each(function (i) {
-          if (i === 4) {
-            $(this).removeClass("active").addClass("active");
-          }
-          else {
-            $(this).removeClass("active");
-          }
+        fileName = window.location.href.substring(window.location.href.lastIndexOf('/')+1)
+        $('a[href="'+fileName+'"]').parents("#navigation_buttons li").each(function (i) {
+            $(this).removeClass().addClass("active");
         });
 
         d3.json('files/install_autocomplete.json', function(json) {

--- a/Visual/package_dep_graph.php
+++ b/Visual/package_dep_graph.php
@@ -10,16 +10,9 @@
     <!-- JQuery Buttons -->
     <script>
       $(function() {
-        $( "button" ).button().click(function(event){
-          event.preventDefault();
-        });
-        $('#navigation_buttons li').each(function (i) {
-          if (i === 3) {
+        fileName = window.location.href.substring(window.location.href.lastIndexOf('/')+1)
+        $('a[href="'+fileName+'"]').parents("#navigation_buttons li").each(function (i) {
             $(this).removeClass().addClass("active");
-          }
-          else {
-            $(this).removeClass();
-          }
         });
       });
     </script>

--- a/Visual/patchDependency.php
+++ b/Visual/patchDependency.php
@@ -12,13 +12,9 @@
         $( "button" ).button().click(function(event){
           event.preventDefault();
         });
-        $('#navigation_buttons li').each(function (i) {
-          if (i === 4) {
-            $(this).removeClass("active").addClass("active");
-          }
-          else {
-            $(this).removeClass("active");
-          }
+        fileName = window.location.href.substring(window.location.href.lastIndexOf('/')+1)
+        $('a[href="'+fileName+'"]').parents("#navigation_buttons li").each(function (i) {
+            $(this).removeClass().addClass("active");
         });
 
         d3.json('files/packages_autocomplete.json', function(json) {

--- a/Visual/vista_menus.php
+++ b/Visual/vista_menus.php
@@ -12,14 +12,9 @@
         $( "button" ).button().click(function(event){
           event.preventDefault();
         });
-
-        $('#navigation_buttons li').each(function (i) {
-          if (i === 1) {
+        fileName = window.location.href.substring(window.location.href.lastIndexOf('/')+1)
+        $('a[href="'+fileName+'"]').parents("#navigation_buttons li").each(function (i) {
             $(this).removeClass().addClass("active");
-          }
-          else {
-            $(this).removeClass();
-          }
         });
         d3.json('files/menu_autocomplete.json', function(json) {
           var sortedjson = json.sort(function(a,b) { return a.label.localeCompare(b.label); });

--- a/Visual/vista_pkg_dep.php
+++ b/Visual/vista_pkg_dep.php
@@ -10,13 +10,9 @@
     <?php include_once "vivian_google_analytics.php" ?>
     <script>
       $(function() {
-        $('#navigation_buttons li').each(function (i) {
-          if (i === 3) {
+        fileName = window.location.href.substring(window.location.href.lastIndexOf('/')+1)
+        $('a[href="'+fileName+'"]').parents("#navigation_buttons li").each(function (i) {
             $(this).removeClass().addClass("active");
-          }
-          else {
-            $(this).removeClass();
-          }
         });
       });
     </script>

--- a/Visual/vista_pkg_dep_chart.php
+++ b/Visual/vista_pkg_dep_chart.php
@@ -10,13 +10,9 @@
     <?php include_once "vivian_google_analytics.php" ?>
     <script>
       $(function() {
-        $('#navigation_buttons li').each(function (i) {
-          if (i === 3) {
+        fileName = window.location.href.substring(window.location.href.lastIndexOf('/')+1)
+        $('a[href="'+fileName+'"]').parents("#navigation_buttons li").each(function (i) {
             $(this).removeClass().addClass("active");
-          }
-          else {
-            $(this).removeClass();
-          }
         });
       });
     </script>


### PR DESCRIPTION
Reconfigure the ViViaN menu bar highlighting to search for the href that
contains the name of the page and then look through the parents for the
object to make active.