### PR TITLE
Add tooltip to requirements nodes

### DIFF
--- a/Visual/bff_demo.php
+++ b/Visual/bff_demo.php
@@ -202,7 +202,10 @@ function node_onMouseOver(d) {
     if (d.number !== undefined){
       header.text("" + d.number);
     }
-    else{
+    else if (d.isRequirement) {
+      header.html("Name: " + d.name + " </br></br> Type: " + d.type + "</br></br>Date of Update: " + d.dateUpdated);
+    }
+    else {
       return;
     }
     toolTip.style("left", (d3.event.pageX + 20) + "px")
@@ -221,6 +224,11 @@ function getRequirementsURL(d){
   }
 
   return outstring
+}
+
+function node_onMouseOut(d) {
+  header.text("");
+  toolTip.style("opacity", "0");
 }
 
 function generateNSRURL(d) {


### PR DESCRIPTION
Add a tooltip to the nodes which show the same information as the
coloring of the node. It should show the name, the type of requirement,
and the date of update of the requirement

OSHERA-Id: https://issues.osehra.org/browse/VIVIAN-338