### PR TITLE
Fix capitalization in ViViaN paths

### DIFF
--- a/Visual/bff_demo.php
+++ b/Visual/bff_demo.php
@@ -109,7 +109,7 @@ var shapeLegend = [{name: "Framework Grouping (Collapsed)", shape: "triangle-up"
 renderWindow();
 function renderWindow() {
   d3.json("files/bff.json", function(BFFjson) {
-    d3.json("files/Requirements.json", function(reqjson) {
+    d3.json("files/requirements.json", function(reqjson) {
       resetAllNode(BFFjson);
       chart.on("node", "event", "mouseover", node_onMouseOver)
          .on("node", "event","mouseout", node_onMouseOut)

--- a/Visual/vista_menus.php
+++ b/Visual/vista_menus.php
@@ -9,8 +9,8 @@
     <!-- JQuery Buttons -->
     <script>
       var pathDict = {
-                      "#19":{"prefix":"","fileLoc":"files/Menus/19", "sourceLoc":"files/19/19-", "initFile":"9","desc":"This page is displaying the menu entries from the OPTION file"},
-                      "#101":{"prefix":"protocol_","fileLoc":"files/Menus/101","sourceLoc":"files/101/101-","initFile":"2590","desc":"This page is displaying the menu entries from the PROTOCOL file"}
+                      "#19":{"prefix":"","fileLoc":"files/menus/19", "sourceLoc":"files/19/19-", "initFile":"9","desc":"This page is displaying the menu entries from the OPTION file"},
+                      "#101":{"prefix":"protocol_","fileLoc":"files/menus/101","sourceLoc":"files/101/101-","initFile":"2590","desc":"This page is displaying the menu entries from the PROTOCOL file"}
       }
       $(window).on('hashchange', function() {
         location.reload();


### PR DESCRIPTION
Ensure that both the Menu display and the name of the requirements JSON
file are correctly capitalized to match what is being generated by the
OSEHRA Python scripts

Capitalization of menus:

https://github.com/OSEHRA/VistA/commit/3d1aa9314d615cc1cf7bc8ed89a1aea8e1eced37#diff-de0b36ffed5ec1bfd7713aae07ebed20R393

Capitalization of requirements:
https://github.com/OSEHRA/VistA/blob/master/Utilities/Dox/PythonScripts/RequirementsParser.py#L45