### PR TITLE
Match DataTables usage in ViViaN

### DIFF
--- a/Visual/queryVis_stats.php
+++ b/Visual/queryVis_stats.php
@@ -323,7 +323,13 @@ $('#filteredObjs').accordion({heightStyle: 'content'}).show();
                     orientation: 'landscape',
                     pageSize: 'LEGAL',
                     exportOptions: {
-                        columns: ':visible'
+                        columns: ':visible',
+                        format: {
+                            body: function(html, indx, node) {
+                                var entryList = html.split("</li>");
+                                return $("<div/>").html(entryList.join("|")).text();
+                            }
+                        }
                     }
                 },
                 {
@@ -332,7 +338,31 @@ $('#filteredObjs').accordion({heightStyle: 'content'}).show();
                     orientation: 'landscape',
                     pageSize: 'LEGAL',
                     exportOptions: {
-                        columns: ':visible'
+                        columns: ':visible',
+                        format: {
+                           body: function(html, indx, node) {
+                              var entryList = html.split("</li>");
+                              var parsedList = []
+                              entryList.forEach(function(d) {
+                                  if (d.indexOf("<li>") != -1) {
+                                      parsedList.push("* " + d)
+                                  } else {
+                                      parsedList.push(d)
+                                  }
+                              });
+                              return $("<div/>").html(parsedList.join("  ")).text();
+                           }
+                        }
+                    },
+                    customize: function (doc) {
+                        // Taken from https://stackoverflow.com/questions/35642802/datatables-export-pdf-with-100-width
+                        var colCount = new Array();
+                        var length = $('#tables_placeholder tbody tr:first-child td').length;
+                        console.log('length / number of td in report one record = '+length);
+                        $('#tables_placeholder').find('tbody tr:first-child td').each(function(){
+                            colCount.push(parseFloat(100 / length)+'%');
+                        });
+                        doc.content[1].table.widths = colCount;
                     }
                 }
 


### PR DESCRIPTION
Match the datatables usage of the VistA FileManGlobalDataParser in the
display found in the queryViz.  Ensure that the columns are shrunk to
prevent the table from scrolling off the edge of the page in a PDF.