### PR TITLE
Switch to using JQueryUI tooltip

### DIFF
--- a/Visual/patchDependency.php
+++ b/Visual/patchDependency.php
@@ -88,7 +88,6 @@ var legendShapeChart = d3.chart.treeview()
 var initPackage = "Barcode Medication Administration";
 var initInstall = "PSB*3.0*68";
 var targetPackage = initPackage;
-var toolTip = d3.select(document.getElementById("toolTip"));
 var header = d3.select(document.getElementById("header1"));
 var installDateTip = d3.select(document.getElementById("installDate"));
 var originalTransform = [300,300];
@@ -166,10 +165,8 @@ function appendPackageInformation (d, json, depth){
 function node_onMouseOver(d) {
   header.text("Install Name: " + d.name + "\r\n");
   if (d.installDate) {  installDateTip.text("Install Date: " + d.installDate);}
-  toolTip.style("left", (d3.event.pageX + 20) + "px")
-         .style("top", (d3.event.pageY + 5) + "px")
-         .style("opacity", ".9");
 
+  $( document ).uitooltip('option', 'content', $("#toolTip").html())
   var nodes = d3.selectAll("g.node")
                 .filter( function (node) {return (node.name == d.name)})
                 .classed('active',true);
@@ -177,9 +174,6 @@ function node_onMouseOver(d) {
 }
 
 function node_onMouseOut(d) {
-  header.text("");
-  installDateTip.text("");
-  toolTip.style("opacity", "0");
   var nodes = d3.selectAll("g.node")
                 .filter( function (node) {return (node.name == d.name)})
                 .classed('active',false);

--- a/Visual/style.css
+++ b/Visual/style.css
@@ -84,7 +84,7 @@ a:hover {
 }
 /* Tooltip */
 
-div.tooltip {
+div.tooltip, div.ui-tooltip {
     position: absolute;			/* reference for measurement */
     text-align: left;
     pointer-events: none;			/* 'none' tells the mouse to ignore the rectangle */
@@ -102,7 +102,7 @@ div.tooltip {
     box-shadow: 0 1px 5px rgba(0,0,0,0.4);
     -moz-box-shadow: 0 1px 5px rgba(0,0,0,0.4);
     border:1px solid rgba(200,200,200,0.85);
-    z-index: 10000;
+    opacity: 1;
 }
 
 div.tooltipTail {
@@ -120,7 +120,7 @@ div.toolTipBody {
     width:230px;
 }
 
-#toolTip .header {
+#toolTip .header, .ui-tooltip-content .header {
     text-align: left;
     font-size: 14px;
     margin-bottom: 2px;

--- a/Visual/vista_menus.php
+++ b/Visual/vista_menus.php
@@ -281,14 +281,10 @@ function node_onMouseOver(d) {
     headText = headText + "<br>" + "Security Key: " + d.lock + "</br>";
   }
   header.html(headText);
-  toolTip.style("left", (d3.event.pageX + 20) + "px")
-         .style("top", (d3.event.pageY + 5) + "px")
-         .style("opacity", ".9");
+  $( document ).uitooltip('option', 'content', $("#toolTip").html())
 }
 
 function node_onMouseOut(d) {
-  header.text("");
-  toolTip.style("opacity", "0");
 }
 
 function createLegend() {

--- a/Visual/vivian_common_header.php
+++ b/Visual/vivian_common_header.php
@@ -2,11 +2,25 @@
 <link type="text/css" rel="stylesheet" href="style.css"/>
 <!-- Latest compiled and minified JavaScript -->
 <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
+<link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css">
+<link rel="stylesheet" href="//code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css">
+
+<script type="text/javascript"> 
+  $.widget.bridge('uitooltip', $.ui.tooltip);
+  $( document ).uitooltip({
+    classes: {
+        "ui-tooltip": "tooltip"
+    },
+    items: ".node",
+    track: "true",
+    show: false,
+    hide: false
+  })
+</script>
+
 <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
 <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
-<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.0/jquery-ui.min.js"></script>
-<link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.0/themes/smoothness/jquery-ui.css">
-<link rel="stylesheet" href="//code.jquery.com/ui/1.11.0/themes/smoothness/jquery-ui.css">
 <script src="d3/d3.v3.min.js" charset="utf-8"></script>
 <script src="d3.treeview.js" charset="utf-8"></script>
 <script src="d3.dependencyedgebundling.js" charset="utf-8"></script>


### PR DESCRIPTION
instead of creating our own tooltip, use the JQuery UI tooltip to
smartly interact with the edge of the screen.

Start using this tooltip on the pages that allow panning and zooming, the two menu options pages and the install dependency page