### PR TITLE
Add Dependent Patch information

### DIFF
--- a/Visual/d3.treeview.js
+++ b/Visual/d3.treeview.js
@@ -250,6 +250,9 @@ d3.chart.treeview = function(option) {
                 return d.children || d._children ? -10 : 10;
             })
             .attr("dy", ".35em")
+            .attr("transform",  function (d) {
+              return d.children || d._children ? 'translate(-10)': '';
+            })
             .attr("text-anchor", function (d) {
                 return d.children || d._children ? "end" : "start";
             })
@@ -270,12 +273,32 @@ d3.chart.treeview = function(option) {
                 return d.target.id;
             });
 
+    // Introduce arrows on lines, taken from http://jsfiddle.net/tk7Wv/2/
+    _svg.append("svg:defs").selectAll("marker")
+      .data(["backward", "forward"])
+    .enter().append("svg:marker")
+      .attr("id", String)
+      .attr("viewBox", function (d) {
+        return d == 'forward' ? "-15 -5 10 10": "10 -5 10 10"})
+      .attr("refX", 5)
+      .attr("markerWidth", 6)
+      .attr("markerHeight", 6)
+      .attr("orient", "auto")
+    .append("svg:path")
+      .attr("class", "pointer")
+      .attr("d", function (d) {
+        return d == 'forward' ? "M0,-5L10,0L0,5":"M10,-5L0,0L10,5"} )
+      .attr("transform", function (d) {
+        return d == 'forward' ? "translate(-15,0)": "translate(10,0)";});
+
     link.enter().insert("svg:path", "g")
             .attr("class", "link")
             .attr("d", function (d) {
                 var o = {x: source.x0, y: source.y0};
                 return _diagonal({source: o, target: o});
             })
+            .attr("marker-start", function(d) {if(d.source.orientation == "backward") {return "url(#backward)"}})
+            .attr("marker-end",  function(d) { if(d.source.orientation == "forward") {return "url(#forward)"}})
             .style("stroke-dasharray",function(d) {if (d.target.isRequirement) return ("3, 3")})
             .style("stroke-dasharray",function(d) {if (d.source.multi > -1) return ("2, 2")});
 

--- a/Visual/vivian_tree_layout.css
+++ b/Visual/vivian_tree_layout.css
@@ -74,10 +74,15 @@
     stroke: #ccc;
     stroke-width: 1.5px;
   }
-
+  path.pointer {
+    fill: #ccc;
+    stroke: #ccc;
+    stroke-width: 3px;
+  }
   path.link.target {
     stroke-width : 2px;
     stroke : #ff99aa;
   }
-
+  #dependencies, #interface A:hover { text-decoration: none; background-color: #f2f2ff }
+  #dependencies, #interface A:link { text-decoration: underline;}
 </style>


### PR DESCRIPTION
In addition to the original information of patch dependency, add a
toggle to read in patch dependent information.  This will transform the
table to show as "children", the patches which depend upon that patch to
exist.

Ensure the switching mechanism resets both sets of information within
the autocomplete.

Account for patches that may not be depended upon by anything.

The newly implemented arrow head on each line will always point to the dependency.

Requires the generation of additional information by using the branch here: https://github.com/OSEHRA/VistA/pull/224